### PR TITLE
Upgrade to latest `mount`, `boot` & `datomic`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # yurt
 
-  module  |  branch  |  status
-----------|----------|----------
-   yurt   | `master` | [![Circle CI](https://circleci.com/gh/tolitius/yurt/tree/master.png?style=svg)](https://circleci.com/gh/tolitius/yurt/tree/master)
+| module | branch   | status                                   |
+| ------ | -------- | ---------------------------------------- |
+| yurt   | `master` | [![Circle CI](https://circleci.com/gh/tolitius/yurt/tree/master.png?style=svg)](https://circleci.com/gh/tolitius/yurt/tree/master) |
 
 [![Clojars Project](http://clojars.org/yurt/latest-version.svg)](http://clojars.org/yurt)
 
@@ -88,7 +88,7 @@ While having a development Yurt in the REPL, it might be useful to create a test
 
 Usually a test Yurt would be started with a different configuration so, for example, dev and test HTTP server components can run simultaneously on different ports.
 
-This can be done with the `(yurt/build-with)` function:
+This can be done with the `:swap` option of the  `(yurt/build)` function:
 
 ```clojure
 (require '[clojure.edn :as edn])
@@ -96,20 +96,20 @@ This can be done with the `(yurt/build-with)` function:
 ```
 
 ```clojure
-(def test-yurt (yurt/build-with 
-                 (yurt/blueprint) 
-                 {"neo.conf/config" test-config}))
+(def test-yurt (yurt/build
+                 (yurt/blueprint)
+                 {:swap {"neo.conf/config" test-config}}))
 ```
 
-`(build-with)` takes a blueprint and a map where keys are component names, and values are the substitutes (i.e. any values), in this case `test-config` is a substitute.
+The value of the `:swap` key is a map where keys are component names, and values are the substitutes (i.e. any values), in this case `test-config` is a substitute.
 
 ## Building Smaller Yurts
 
-A Yurt can be built with `only` certain components specified:
+A Yurt can be built with `:only` certain components specified:
 
 ```clojure
 dev=> (def bp (yurt/blueprint))
-dev=> (def dev-yurt (yurt/build-only bp #{"neo.conf/config" "neo.app/nrepl"}))
+dev=> (def dev-yurt (yurt/build bp {:only #{"neo.conf/config" "neo.app/nrepl"}}))
 
 INFO  utils.logging - >> starting.. #'neo.conf/config
 INFO  neo.conf - loading config from dev/resources/config.edn
@@ -118,8 +118,8 @@ INFO  utils.logging - >> starting.. #'neo.app/nrepl
 dev=>
 ```
 
-notice it was built with a `build-only` function that takes a blueprint and components
-that this Yurt should be built from. In this case `#{"neo.conf/config" "neo.app/nrepl"}`.
+notice it was built with a `:only` option of the `build` function which specifies which components
+this Yurt should be built from. In this case `#{"neo.conf/config" "neo.app/nrepl"}`.
 
 Here is what the built Yurt looks like:
 
@@ -169,18 +169,15 @@ One arity `:stop` functions is _the only_ requirement Yurt has for the mount app
 
 ## Show me
 
-sure.
+Sure.
+
+There are a [few example apps](https://github.com/tolitius/stater/) built for `mount`. One of them is called [neo](https://github.com/tolitius/stater/tree/master/neo). Yurt comes with an adapted version of the [neo](dev/clj/neo) app, which you can simply start by running:
 
 ```shell
-$ boot repl
+$ boot dev repl
 ```
 
-```clojure
-boot.user=> (dev)
-#object[clojure.lang.Namespace 0x61647fa2 "dev"]
-```
-
-Working with a [neo](dev/clj/neo) `mount` sample app that comes with Yurt sources and has 4 components (`mount` states):
+This modified neo app has 4 components (aka `mount` states):
 
 * `config`, loaded from the files and refreshed on each (reset)
 * `datomic connection` that uses the config to create itself
@@ -248,24 +245,19 @@ dev=> (def test-config (edn/read-string (slurp "dev/resources/test-config.edn"))
 #'dev/test-config
 ```
 
-notice we are building it by the same blueprint:
+notice we are building it by the same blueprint just substituting the config component with the test config:
 
 ```clojure
-dev=> (def test-yurt (yurt/build-with (yurt/blueprint) {"neo.conf/config" test-config}))
+dev=> (def test-yurt (yurt/build (yurt/blueprint)
+                                 {:swap {"neo.conf/config" test-config}}))
 INFO  neo.db - conf:  {:datomic {:uri datomic:mem://test-yurt}, :www {:port 4200}, :nrepl {:host 0.0.0.0, :port 7800}}
 INFO  neo.db - creating a connection to datomic: datomic:mem://test-yurt
 #'dev/test-yurt
 ```
 
-just substituting the config component _with_ the test config:
-
-```clojure
-;; e.g. (yurt/build-with (yurt/blueprint) {"neo.conf/config" test-config})
-```
-
 notice the config ports an datomic uri ^^^.
 
-we can substitute as many components as we want since `build-with` takes a map where keys are the state names, and values are the substitutes (i.e. any values).
+we can substitute as many components as we want since `build ... {:swap {...}}` takes a map where keys are the state names, and values are the substitutes (i.e. any values).
 
 Let's look at what we've built:
 

--- a/boot.properties
+++ b/boot.properties
@@ -1,0 +1,5 @@
+#http://boot-clj.com
+#Sun Jul 09 00:34:04 HKT 2017
+BOOT_CLOJURE_NAME=org.clojure/clojure
+BOOT_CLOJURE_VERSION=1.8.0
+BOOT_VERSION=2.7.1

--- a/build.boot
+++ b/build.boot
@@ -2,28 +2,36 @@
 
 (set-env!
   :source-paths #{"src"}
-  :dependencies '[[mount                          "0.1.10"]
+  :dependencies
+  '[[mount                          "0.1.11"]
+    [org.clojure/clojure            "1.8.0"]
 
-                  ;; deps for sample apps
-                  [datascript                     "0.13.3"    :scope "provided"]
-                  [compojure                      "1.4.0"     :scope "provided"]
-                  [ring/ring-jetty-adapter        "1.1.0"     :scope "provided"]
-                  [cheshire                       "5.5.0"     :scope "provided"]
-                  [ch.qos.logback/logback-classic "1.1.3"     :scope "provided"]
-                  [org.clojure/tools.logging      "0.3.1"     :scope "provided"]
-                  [robert/hooke                   "1.3.0"     :scope "provided"]
-                  [org.clojure/tools.namespace    "0.2.11"    :scope "provided"]
-                  [org.clojure/tools.nrepl        "0.2.12"    :scope "provided"]
-                  [com.datomic/datomic-free       "0.9.5327"  :scope "provided" :exclusions [joda-time]]
+    ;; deps for sample apps
+    [compojure                      "1.6.0"           :scope "provided"]
+    [ring/ring-jetty-adapter        "1.1.1"           :scope "provided"]
+    [cheshire                       "5.7.1"           :scope "provided"]
+    [ch.qos.logback/logback-classic "1.2.3"           :scope "provided"]
+    [org.clojure/tools.logging      "0.4.0"           :scope "provided"]
+    [robert/hooke                   "1.3.0"           :scope "provided"]
+    [org.clojure/tools.namespace    "0.2.11"          :scope "provided"]
+    [org.clojure/tools.nrepl        "0.2.13"          :scope "provided"]
+    [com.datomic/datomic-free       "0.9.5561.50"     :scope "provided"]
 
-                  ;; boot clj
-                  [boot/core                "2.5.1"           :scope "provided"]
-                  [adzerk/bootlaces         "0.1.13"          :scope "test"]
-                  [adzerk/boot-logservice   "1.0.1"           :scope "test"]
-                  [adzerk/boot-test         "1.0.6"           :scope "test"]
-                  [tolitius/boot-stripper   "0.1.0-SNAPSHOT"  :scope "test"]
-                  [tolitius/boot-check      "0.1.1"           :scope "test"]])
+    ;; boot clj
+    [boot/core                      "2.7.1"           :scope "provided"]
+    [adzerk/bootlaces               "0.1.13"          :scope "test"]
+    [adzerk/boot-logservice         "1.1.0"           :scope "test"]
+    [adzerk/boot-test               "1.2.0"           :scope "test"]
+    [tolitius/boot-stripper         "0.1.0-SNAPSHOT"  :scope "test"]
+    [tolitius/boot-check            "0.1.4"           :scope "test"]])
 
+; The repl task updates the data-readers, BUT only after it loads the
+; file specified with the :init option. That file however already contains
+; #db/id reader tags, hence trying to load it would fail.
+;
+; We cannot run this from the dev task either, because it throws this exception:
+;   java.lang.IllegalStateException: Can't set!: *data-readers* from non-binding thread
+(load-data-readers!)
 
 (require '[adzerk.bootlaces :refer :all]
          '[tolitius.boot-check :as check]
@@ -45,14 +53,14 @@
 (deftask dev []
   (set-env! :source-paths #(conj % "dev/clj"))
 
+  (task-options!
+    repl {:init "dev.clj"
+          :init-ns 'dev})
+
   (alter-var-root #'log/*logger-factory*
                   (constantly (log-service/make-factory log4b)))
 
-  (apply set-refresh-dirs (get-env :directories))
-  (load-data-readers!)                             ;; for datomic
-
-  (require 'dev)
-  (in-ns 'dev))
+  (apply set-refresh-dirs (get-env :directories)))
 
 (deftask test []
   (set-env! :source-paths #(conj % "test" "dev/clj"))

--- a/dev/clj/dev.clj
+++ b/dev/clj/dev.clj
@@ -13,7 +13,6 @@
             [neo.options.orders :refer [find-orders add-order]]))
 
 (with-logging-status)
-(load-data-readers!)
 
 (defn refresh []
   (tn/refresh))

--- a/dev/clj/neo/db.clj
+++ b/dev/clj/neo/db.clj
@@ -21,29 +21,21 @@
 
 ;; datomic schema (staging for an example)
 (defn create-schema [conn]
-  (let [schema [{:db/id #db/id [:db.part/db]
-                 :db/ident :order/symbol
-                 :db/valueType :db.type/string
+  (let [schema [{:db/ident       :order/symbol
+                 :db/valueType   :db.type/string
                  :db/cardinality :db.cardinality/one
-                 :db/index true
-                 :db.install/_attribute :db.part/db}
+                 :db/index       true}
 
-                {:db/id #db/id [:db.part/db]
-                 :db/ident :order/bid
-                 :db/valueType :db.type/bigdec
-                 :db/cardinality :db.cardinality/one
-                 :db.install/_attribute :db.part/db}
-                
-                {:db/id #db/id [:db.part/db]
-                 :db/ident :order/qty
-                 :db/valueType :db.type/long
-                 :db/cardinality :db.cardinality/one
-                 :db.install/_attribute :db.part/db}
+                {:db/ident       :order/bid
+                 :db/valueType   :db.type/bigdec
+                 :db/cardinality :db.cardinality/one}
 
-                {:db/id #db/id [:db.part/db]
-                 :db/ident :order/offer
-                 :db/valueType :db.type/bigdec
-                 :db/cardinality :db.cardinality/one
-                 :db.install/_attribute :db.part/db}]]
+                {:db/ident       :order/qty
+                 :db/valueType   :db.type/long
+                 :db/cardinality :db.cardinality/one}
+
+                {:db/ident       :order/offer
+                 :db/valueType   :db.type/bigdec
+                 :db/cardinality :db.cardinality/one}]]
 
         @(d/transact conn schema)))


### PR DESCRIPTION
and all other dependencies too, because I was getting various errors regarding
> Can't set!: *data-readers* from non-binding thread
or
> Can't set!: *ns* from non-binding thread
and it complained about my dependencies in my `~/.boot/profile.boot` not being a vector, etc, etc

so I fed up and modernized everything I could.